### PR TITLE
Update for xml2 version 1.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(person("Colin", "Millar", role=c("aut","cre"), email="colin.millar@
              person("Carlos", "Pinto", role=c("aut")))
 Imports: png,
          httr,
-         xml2,
+         xml2 (>= 1.2.0),
          openssl,
          icesVocab
 Suggests: testthat
@@ -17,3 +17,4 @@ Description: R interface to access the web services of the ICES Stock Assessment
 License: GPL (>= 2)
 URL: http://sg.ices.dk
 RoxygenNote: 6.0.1
+Remotes: hadley/xml2

--- a/R/SAGxml.R
+++ b/R/SAGxml.R
@@ -70,7 +70,7 @@ createSAGxml <- function(info, fishdata) {
 #' @export
 readSAGxml <- function(file) {
   # read in xml file, and convert to list
-  out <- xml2::as_list(xml2::read_xml(file))
+  out <- xml2::as_list(xml2::read_xml(file))[[1L]]
 
   sag_parse(out, type = "upload")
 }

--- a/R/uploadXMLFile.R
+++ b/R/uploadXMLFile.R
@@ -15,6 +15,6 @@ uploadXMLFile <- function(txt) {
                     httr::content_type("application/x-www-form-urlencoded"),
                     `Content-Length` = nchar(body))
     message(httr::http_status(x)$message)
-    unlist(xml2::as_list(httr::content(x)))
+    unlist(xml2::as_list(httr::content(x))[[1L]])
 }
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -60,7 +60,7 @@ sag_get <- function(uri) {
 
   # return as list
   if (httr::http_type(resp) == "text/xml") {
-    xml2::as_list(httr::content(resp))
+    xml2::as_list(httr::content(resp))[[1L]]
   } else {
     warning("in SAG API - ", httr::content(resp), call. = FALSE)
     if (grepl("Web Service method name is not valid", httr::content(resp))) {


### PR DESCRIPTION
The upcoming release of xml2 fixes a bug which caused
`as_list.xml_document()` to omit the root node in the returned list.

Unfortunately this change broke icesSAG, which is fixed by these
changes.

Once xml2 is released on CRAN (likely in the next few days or weeks) you can remove the `Remotes:` line and submit a new release of icesSAG to CRAN.

Sorry for the breakage!